### PR TITLE
Preserve order of mapping fields using 'collections.OrderedDict'. 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ Changes
 - Add contributing.md and update docs. See
   https://github.com/Pylons/peppercorn/issues/13
 
+- Preserve ordering of mapping fields using ``collections.OrderedDict``. See
+  https://github.com/Pylons/peppercorn/issues/11
 
 0.5 (2014-09-29)
 ----------------

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -105,6 +105,7 @@ Contributors
 - Atsushi Odagiri, 2012/02/05
 - Valentin Ungureanu, 2012/02/06
 - Shane Hathaway, 2013/04/13
+- Tres Seaver, 2013/05/06
 - Tim Tisdall, 2015/04/21
 - Steffen Allner, 2018/08/14
 - Steve Piercy, 2018/08/08

--- a/peppercorn/__init__.py
+++ b/peppercorn/__init__.py
@@ -1,8 +1,4 @@
-
-def data_type(value):
-    if ':' in value:
-        return [ x.strip() for x in value.rsplit(':', 1) ]
-    return ('', value.strip())
+import collections
 
 START = '__start__'
 END = '__end__'
@@ -13,9 +9,14 @@ IGNORE = 'ignore'
 TYPS = (SEQUENCE, MAPPING, RENAME, IGNORE)
 
 
+def data_type(value):
+    if ':' in value:
+        return [ x.strip() for x in value.rsplit(':', 1) ]
+    return ('', value.strip())
+
+
 def parse(tokens):
-    """ Infer a data structure from the ordered set of fields and
-    return it."""
+    """ Return a data structure inferred from an ordered set of fields."""
     target = typ = None
     out = []    # [(key, value)]
     stack = []  # [(target, typ, out)]
@@ -33,7 +34,7 @@ def parse(tokens):
             if typ == SEQUENCE:
                 parsed = [v for (k, v) in out]
             elif typ == MAPPING:
-                parsed = dict(out)
+                parsed = collections.OrderedDict(out)
             elif typ == RENAME:
                 parsed = out[0][1] if out else ''
             elif typ == IGNORE:
@@ -51,4 +52,4 @@ def parse(tokens):
     if stack:
         raise ValueError("Not enough end markers")
 
-    return dict(out)
+    return collections.OrderedDict(out)

--- a/peppercorn/tests.py
+++ b/peppercorn/tests.py
@@ -59,15 +59,21 @@ class TestParse(unittest.TestCase):
         return fields
 
     def _assertFieldsResult(self, result):
-        self.assertEqual(
-            result,
-            {'series':
-             {'name':'date series 1',
-              'dates': [['10', '12', '2008'],
-                        ['10', '12', '2009']],
-              },
-             'name': 'project1',
-             'title': 'Cool project'})
+        import collections
+
+        sub = collections.OrderedDict()
+        sub['name'] ='date series 1'
+        sub['dates'] =[
+            ['10', '12', '2008'],
+            ['10', '12', '2009'],
+        ]
+
+        expected = collections.OrderedDict()
+        expected['name'] = 'project1'
+        expected['title'] = 'Cool project'
+        expected['series'] = sub
+
+        self.assertEqual(result, expected)
 
     def test_bare(self):
         fields = self._getFields()


### PR DESCRIPTION
Closes #11.

Also, sign `CONTRIBUTORS.txt` as of date of my first commit.