### PR TITLE
Provide a compatibility options with broken data set order.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,35 @@
 Changes
 =======
 
+0.7 (unreleased)
+----------------
+
+- Provide a compatibility option for clients that do not implement the "list of
+  tuples" processing according to the HTML spec's "Constructing the form data
+  set" algorithm.
+
+  To help those clients you can suffix each field name with a unique marker
+  so that they will properly preserver order and thus emulate the 
+  "list of tuples" behaviour. 
+
+  If your application relies on this, then provide the ``unique_key_separator``
+  argument to the parse function ``parse(fields, unique_key_separator=":"")`` and
+  suffix the input field names accordingly. The actual IDs do not matter,
+  as long as the combination of field name + id ends up as unique. :
+
+    <input type="hidden" name="__start__:1234" value="series:sequence"/>
+    <input type="hidden" name="name:1234" value="Bob" />
+    <input type="hidden" name="__end__:1234" />
+
+    <input type="hidden" name="__start__:1235" value="series:sequence"/>
+    <input type="hidden" name="name:1235" value="Ken" />
+    <input type="hidden" name="__end__:1235" />
+
+  For readability you can reuse the same ID on start/end markers, but they could
+  also be different and don't have to be numbers, UUIDs would work as well but
+  will increase payload size.
+
+
 0.6 (2018-08-24)
 ----------------
 

--- a/peppercorn/__init__.py
+++ b/peppercorn/__init__.py
@@ -13,7 +13,7 @@ IGNORE = 'ignore'
 TYPS = (SEQUENCE, MAPPING, RENAME, IGNORE)
 
 
-def parse(tokens):
+def parse(tokens, unique_key_separator=None):
     """ Infer a data structure from the ordered set of fields and
     return it."""
     target = typ = None
@@ -22,6 +22,9 @@ def parse(tokens):
 
     for token in tokens:
         key, val = token
+        if unique_key_separator:
+            key = key.rsplit(unique_key_separator, maxsplit=1)[0]
+
         if key == START:
             stack.append((target, typ, out))
             target, typ = data_type(val)
@@ -46,7 +49,7 @@ def parse(tokens):
             target = prev_target
             typ = prev_typ
         else:
-            out.append(token)
+            out.append((key, val))
 
     if stack:
         raise ValueError("Not enough end markers")


### PR DESCRIPTION
I stumbled over an incorrect form data set construction order in HTMX. I made a bug report there
(https://github.com/bigskysoftware/htmx/issues/1686) but need a work around in the meantime.

They seem to take care of ordering as long as the names are unique.

This is backwards compatible to avoid downstream breakage.