### PR TITLE
Add a new quasi-functional test using 'multipart'

### DIFF
--- a/peppercorn/tests.py
+++ b/peppercorn/tests.py
@@ -94,6 +94,13 @@ def cgi_fieldstorage(body_bytesio, environ_for_mpfs, headers):
     )
 
 
+@pytest.fixture(scope="function")
+def multipart_multipartparser(body_bytesio):
+    from multipart import MultipartParser
+
+    return MultipartParser(body_bytesio, BOUNDARY)
+
+
 def _assertFieldsResult(result):
     assert result == {
         "series": {
@@ -123,6 +130,18 @@ def test_w_cgi_fieldstorage(cgi_fieldstorage):
 
     for field in cgi_fieldstorage.list:
         fields.append((field.name, field.value))
+
+    result = parse(fields)
+
+    _assertFieldsResult(result)
+
+
+def test_w_multipart_multipartparse(multipart_multipartparser):
+    from peppercorn import parse
+
+    fields = [
+        (part.name, part.value) for part in list(multipart_multipartparser)
+    ]
 
     result = parse(fields)
 

--- a/peppercorn/tests.py
+++ b/peppercorn/tests.py
@@ -93,7 +93,7 @@ def cgi_fieldstorage(
         fp=body_bytesio,
         environ=cgi_environ,
         keep_blank_values=1,
-        headers=headers,
+        headers=cgi_headers,
     )
 
 

--- a/peppercorn/tests.py
+++ b/peppercorn/tests.py
@@ -126,10 +126,9 @@ def test_bare(fields):
 def test_w_cgi_fieldstorage(cgi_fieldstorage):
     from peppercorn import parse
 
-    fields = []
-
-    for field in cgi_fieldstorage.list:
-        fields.append((field.name, field.value))
+    fields = [
+        (part.name, part.value) for part in cgi_fieldstorage.list
+    ]
 
     result = parse(fields)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ docs = [
 testing = [
     "pytest",
     "pytest-cov",
+    "multipart",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
`peppercorn` doesn't actually *use* the stdlib's deprecated `cgi.FieldStorage`, except in a quasi-functional test
which builds one only to tear out the name-value pairs to hand to peppercorn's own 'parse'.

The rationale is that `peppercorn` is mostly used to parse serialized form data, passed in an HTTP POST request body encoded as `multipart/form-data:  because 'peppercorn' sits in the part of the WSGI space dependent mostly dominated by `WebOb`, which still using `cgi.FieldStorage`, we have wanted to demonstrate that we could consume such data trivially.

However, the `cgi` module is [slated to be removed from the standard library in Python 3.13](https://peps.python.org/pep-0594/#cgi).

This branch therefore adds a similar quasi-functional test, using instead the `MultipartParser` from the third-party [`multipart` package](https://github.com/defnull/multipart) recommended by PEP-594 as the appropriate replacement for `cgi.FieldStorage`.  Perhaps it might help spark thinking about updates to `WebOb` for compatibility with Python >= 3.13.